### PR TITLE
Dockerfile fixes - chown volumes and su to jerakia user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.6
-MAINTAINER Craig Dunn <craig@craigdunn.org>
+
+LABEL maintainer="Craig Dunn <craig@craigdunn.org>"
 
 ARG RUNTIME_UID=99901
 ARG RUNTIME_GID=99901

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ ADD bin ./bin
 COPY Gemfile /usr/app
 COPY jerakia.gemspec .
 
+COPY entrypoint.sh ./
+RUN chmod ugo+x ./entrypoint.sh
+
 RUN bundle config build.nokogiri --use-system-libraries && \
     bundle install --without development test
 
@@ -36,6 +39,5 @@ VOLUME /etc/jerakia/policy.d /var/lib/jerakia/plugins /var/lib/jerakia/data /var
 
 RUN rm -rf /var/cache/apk*
 
-USER jerakia
 ENTRYPOINT ["jerakia"]
 CMD ["server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ VOLUME /etc/jerakia/policy.d /var/lib/jerakia/plugins /var/lib/jerakia/data /var
 
 RUN rm -rf /var/cache/apk*
 
-ENTRYPOINT ["jerakia"]
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["server"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chown -Rv jerakia:jerakia {/etc/jerakia/policy.d,/var/lib/jerakia/plugins,/var/lib/jerakia/data,/var/lib/jerakia/schema,/var/db/jerakia,/etc/jerakia/config}
+
+su jerakia -s /bin/bash -c "jerakia $@"


### PR DESCRIPTION
Workaround issue where explicitly mounted volumes have user and group set to root.

This workaround creates an entrypoint that `chown`s the directories and then `su` runs the server as jerakia user.

### References
#122 