### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,54 @@
-FROM alpine:3.6
+FROM alpine:3.7
 MAINTAINER Craig Dunn <craig@craigdunn.org>
 
-ARG RUNTIME_UID=99901
-ARG RUNTIME_GID=99901
+ENV JERAKIA_CONFIG="/etc/jerakia/config/jerakia.yaml"
 
-ENV RUBYOPTS="-W0"  JERAKIA_CONFIG="/etc/jerakia/config/jerakia.yaml"
+RUN apk update && apk upgrade && \
+    apk add bash \
+            curl-dev \
+            ruby-dev \
+            build-base && \
+    apk add ruby \
+            ruby-bundler \
+            ruby-io-console \
+            sqlite-dev \
+            ruby-nokogiri
 
-RUN apk update && apk upgrade && apk add bash curl-dev ruby-dev build-base && \
-    apk add ruby ruby-bundler ruby-io-console sqlite-dev ruby-nokogiri
-
-
-RUN addgroup -g $RUNTIME_GID jerakia && adduser -u $RUNTIME_UID -G jerakia jerakia -S && \
-    mkdir -p /usr/app /var/log/jerakia /etc/jerakia /etc/jerakia/policy.d /var/db/jerakia /var/lib/jerakia/plugins /var/lib/jerakia/schema /etc/jerakia/config && \
-    chown jerakia.jerakia -R /usr/app /var/log/jerakia /var/db/jerakia /var/lib/jerakia/plugins /var/lib/jerakia/schema /etc/jerakia
-
-VOLUME /etc/jerakia/policy.d /var/lib/jerakia/plugins /var/lib/jerakia/data /var/lib/jerakia/schema /var/db/jerakia /etc/jerakia/config
+RUN addgroup -g 99901 jerakia && \
+    adduser -u 99901 -G jerakia jerakia -S && \
+    mkdir -p /usr/app \
+             /etc/jerakia/policy.d \
+             /etc/jerakia/config \
+             /var/db/jerakia \
+             /var/lib/jerakia/plugins \
+             /var/lib/jerakia/schema \
+             /var/log/jerakia && \
+    chown jerakia.jerakia -R /usr/app \
+                             /etc/jerakia \
+                             /var/db/jerakia \
+                             /var/lib/jerakia \
+                             /var/log/jerakia
 
 WORKDIR /usr/app
-
 ADD lib ./lib
 ADD bin ./bin
 COPY Gemfile /usr/app
 COPY jerakia.gemspec .
 
+ENV RUBYOPT="-W0"
 RUN bundle config build.nokogiri --use-system-libraries && \
     bundle install --without development test
-
 RUN bundle config build.nokogiri --use-system-libraries && \
     bundle install --without development test &&\
-    bundle  exec gem build jerakia.gemspec && \
+    bundle exec gem build jerakia.gemspec && \
     bundle exec gem install --no-rdoc --no-ri ./jerakia*.gem
 
-VOLUME /etc/jerakia/policy.d /var/lib/jerakia/plugins /var/lib/jerakia/data /var/lib/jerakia/schema /var/db/jerakia /etc/jerakia/config
+VOLUME /etc/jerakia \
+       /var/db/jerakia \
+       /var/lib/jerakia
 
 RUN rm -rf /var/cache/apk*
 
 USER jerakia
 ENTRYPOINT ["jerakia"]
-CMD ["server"]
+CMD ["server", "--bind", "0.0.0.0"]


### PR DESCRIPTION
Fixes #127 and prepares for a "write a known token to volume" approach
to the use case for #122 #123

* Maint: Upgrade alpine
* Cleanup: Removed redundant lines
* Change: Explicitly specify uid and gid in without using ARG
* Change: Reduce the number of VOLs to be more practical
* FIX: Specify correct RUBYOPT env var to slience warnings
* FIX: Bind the server to 0.0.0.0 instead of localhost