### PR TITLE
[BREAK] HTTP Datasource: default lookup_key false

### DIFF
--- a/lib/jerakia/datasource/http.rb
+++ b/lib/jerakia/datasource/http.rb
@@ -23,7 +23,7 @@ class Jerakia::Datasource::Http < Jerakia::Datasource::Instance
   # look up the key from a hash that gets returned.  This flag will be
   # set to default of false in Jerakia 3.0
   #
-  option(:lookup_key, :default => true) { |opt|
+  option(:lookup_key, :default => false) { |opt|
     [TrueClass,FalseClass].include?(opt.class)
   }
 

--- a/lib/jerakia/version.rb
+++ b/lib/jerakia/version.rb
@@ -3,5 +3,5 @@ class Jerakia
   #
   # This should be updated when a new gem is released and it is read from the gemspec file
   #
-  VERSION = '3.0.0-pre3'.freeze
+  VERSION = '3.0.0-pre4'.freeze
 end


### PR DESCRIPTION
    As per the documentation and comments, lookup_key is changing
    to a default value of false in Jerakia 3.0 - this is mainly
    due to the limited flexibility offered by the HTTP datasource
    in digging into data structures using lookup_key - which expects
    the top level keys of the returned hash from the HTTP end point
    to be the same as the request keys... This is rarely enough
    The better way of doing this is to set `lookup_key` to `false`
    and use the `dig` filter in the lookup which is far more
    flexible.

