### PR TITLE
add merge option deep_all to be used with keyless lookups

### DIFF
--- a/lib/jerakia/dataset/key.rb
+++ b/lib/jerakia/dataset/key.rb
@@ -82,19 +82,38 @@ class Jerakia
       private
 
       def add_to_value(newval)
-        case @merge
-        when :array
-          @value ||= []
-          @value << newval
-          @value.flatten!
-        when :hash
-          @value ||= {}
-          newhash = newval.merge(@value)
-          @value = newhash
-        when :deep_hash
-          @value ||= {}
-          newhash = newval.deep_merge!(@value)
-          @value = newhash
+        case newval
+        when TrueClass, FalseClass
+          @value ||= false
+          @value = newval
+        when Fixnum
+          @value ||= 0
+          @value = newval
+        when String
+          @value ||= ""
+          @value = newval
+        when Array
+          case @merge
+          when :array, :deep_all
+            @value ||= []
+            @value << newval
+            @value.flatten!
+          else
+            @value = newval
+          end
+        when Hash
+          case @merge
+          when :hash
+            @value ||= {}
+            newhash = newval.merge(@value)
+            @value = newhash
+          when :deep_hash, :deep_all
+            @value ||= {}
+            newhash = newval.deep_merge!(@value)
+            @value = newhash
+          else
+            @value = newval
+          end
         end
       end
     end

--- a/lib/jerakia/dataset/key.rb
+++ b/lib/jerakia/dataset/key.rb
@@ -83,15 +83,8 @@ class Jerakia
 
       def add_to_value(newval)
         case newval
-        when TrueClass, FalseClass
-          @value ||= false
-          @value = newval
-        when Fixnum
-          @value ||= 0
-          @value = newval
-        when String
-          @value ||= ""
-          @value = newval
+        when String, Integer, TrueClass, FalseClass
+          @value ||= newval
         when Array
           case @merge
           when :array, :deep_all
@@ -99,7 +92,7 @@ class Jerakia
             @value << newval
             @value.flatten!
           else
-            @value = newval
+            @value ||= newval
           end
         when Hash
           case @merge
@@ -112,13 +105,11 @@ class Jerakia
             newhash = newval.deep_merge!(@value)
             @value = newhash
           else
-            @value = newval
+            @value ||= newval
           end
         end
       end
+
     end
   end
 end
-
-
-

--- a/spec/features/keyless_spec.rb
+++ b/spec/features/keyless_spec.rb
@@ -1,0 +1,655 @@
+require 'spec_helper'
+
+describe Jerakia do
+  let(:subject) { Jerakia.new(:config =>  "#{JERAKIA_ROOT}/test/fixtures/etc/jerakia/jerakia.yaml") }
+  let(:request) { Jerakia::Request.new }
+  let(:answer) { subject.lookup(request) }
+
+  describe 'Keyless' do
+    context 'first result lookup without schema' do
+      let(:request) do
+        Jerakia::Request.new(
+          policy: 'schema',
+          key: nil,
+          metadata: { env: 'dev' },
+          namespace: ['test'],
+          lookup_type: :first,
+          use_schema: false
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should contain the first result' do
+        expect(answer.payload).to eq({
+          "teststring" => "valid_string",
+          "accounts" => {
+            "oracle" => {
+              "uid" => 500
+            }
+          },
+          "beers" => [
+            "cruzcampo",
+            "sanmiguel"
+            ],
+          "hash" => {
+            "key1" => {
+              "element2" => "env"
+            },
+            "key2" => {
+              "element3" => {
+                "subelement3" => "env"
+              }
+            },
+            "key3" => "env"
+          },
+          "admins" => [
+            "joseph",
+            "gerald",
+            "craig",
+          ],
+          "jewels" => [
+            "ruby",
+            "opal",
+            "diamond",
+          ],
+          "cities" => {
+            "uk" => "london",
+            "spain" => "madrid",
+          },
+          "databases" => {
+            "mdb" => {
+              "syncrepl" => {
+                "foo" => "bar",
+                "taz" => "tango",
+              }
+            }
+          },
+          "boolfalse" => false,
+          "booltrue" => true,
+          "msgpack" => {
+            "values"=>{
+              1=>"Test 1",
+              "2"=>"Test 2"
+            }
+          },
+          "null_value" => nil,
+          "passwords" => {
+            "root"=>"vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+          },
+          "root_password" => "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA==",
+          "sub_value" => "Environment is %{env}",
+          "subhash" => {
+            "walk"=>{
+              "another"=>{
+                "deeper"=>"%{env}"
+              },
+              "replace"=>"%{env}"
+            }
+          },
+          "users" => [
+            "joshua",
+            "craig",
+            "karina",
+            "max"
+          ]
+        })
+      end
+    end
+
+    context 'first result lookup with schema cascade' do
+      let(:request) do
+        Jerakia::Request.new(
+          policy: 'schema',
+          key: nil,
+          metadata: { env: 'dev' },
+          namespace: ['test'],
+          lookup_type: :first,
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should contain the first result' do
+        expect(answer.payload).to eq({
+          "teststring" => "valid_string",
+          "accounts" => {
+            "oracle" => {
+              "uid" => 500
+            }
+          },
+          "beers" => [
+            "cruzcampo",
+            "sanmiguel"
+          ],
+          "hash" => {
+            "key1" => {
+              "element2" => "env"
+            },
+            "key2" => {
+              "element3" => {
+                "subelement3" => "env"
+              }
+            },
+            "key3" => "env"
+          },
+          "admins" => [
+            "joseph",
+            "gerald",
+            "craig",
+          ],
+          "jewels" => [
+            "ruby",
+            "opal",
+            "diamond",
+            "quartz",
+            "topaz",
+          ],
+          "cities" => {
+            "uk" => "london",
+            "spain" => "madrid",
+            "argentina" => "buenos aires",
+            "france"=>"paris",
+          },
+          "databases" => {
+            "mdb" => {
+              "syncrepl" => {
+                "foo" => "bar",
+                "taz" => "tango",
+              }
+            }
+          },
+          "boolfalse" => false,
+          "booltrue" => true,
+          "msgpack" => {
+            "values"=>{
+              1=>"Test 1",
+              "2"=>"Test 2"
+            }
+          },
+          "null_value" => nil,
+          "passwords" => {
+            "root"=>"vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+          },
+          "root_password" => "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA==",
+          "sub_value" => "Environment is %{env}",
+          "subhash" => {
+            "walk"=>{
+              "another"=>{
+                "deeper"=>"%{env}"
+              },
+              "replace"=>"%{env}"
+            }
+          },
+          "users" => [
+            "joshua",
+            "craig",
+            "karina",
+            "max"
+          ]
+        })
+      end
+    end
+
+
+    context 'cascade merge array result lookup' do
+      let(:request) do
+        Jerakia::Request.new(
+          policy: 'schema',
+          key: nil,
+          metadata: { env: 'dev' },
+          namespace: ['test'],
+          lookup_type: :cascade,
+          merge: :array,
+          use_schema: false
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should contain the string valid_string' do
+        expect(answer.payload).to eq({
+          "teststring" => "valid_string",
+          "accounts" => {
+            "oracle" => {
+              "uid" => 500
+            }
+          },
+          "beers" => [
+            "cruzcampo",
+            "sanmiguel",
+            "estrella",
+            "victoria",
+          ],
+          "hash" => {
+            "key1" => {
+              "element2" => "env"
+            },
+            "key2" => {
+              "element3" => {
+                "subelement3" => "env"
+              }
+            },
+            "key3" => "env"
+          },
+          "admins" => [
+            "joseph",
+            "gerald",
+            "craig",
+            "bill",
+            "susan",
+            "fred",
+            "bob",
+          ],
+          "jewels" => [
+            "ruby",
+            "opal",
+            "diamond",
+            "quartz",
+            "topaz",
+          ],
+          "cities" => {
+            "spain" => "madrid",
+            "uk" => "london",
+          },
+          "databases" => {
+            "mdb" => {
+              "syncrepl" => {
+                "foo" => "bar",
+                "taz" => "tango"
+              }
+            }
+          },
+          "boolfalse" => false,
+          "booltrue" => true,
+          "msgpack" => {
+            "values"=>{
+              1=>"Test 1",
+              "2"=>"Test 2"
+            }
+          },
+          "null_value" => nil,
+          "passwords" => {
+            "root"=>"vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+          },
+          "root_password" => "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA==",
+          "sub_value" => "Environment is %{env}",
+          "subhash" => {
+            "walk"=>{
+              "another"=>{
+                "deeper"=>"%{env}"
+              },
+              "replace"=>"%{env}"
+            }
+          },
+          "users" => [
+            "joshua",
+            "craig",
+            "karina",
+            "max"
+          ]
+        })
+
+      end
+    end
+
+    context 'cascade merge hash result lookup' do
+      let(:request) do
+        Jerakia::Request.new(
+          policy: 'schema',
+          key: nil,
+          metadata: { env: 'dev' },
+          namespace: ['test'],
+          use_schema: false,
+          lookup_type: :cascade,
+          merge: :hash,
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should contain the string valid_string' do
+        expect(answer.payload).to eq({
+          "teststring" => "valid_string",
+          "accounts" => {
+            "admin" => {
+              "uid" => 99
+            },
+            "oracle" => {
+              "uid" => 500
+            }
+          },
+          "beers" => [
+            "cruzcampo",
+            "sanmiguel",
+          ],
+          "hash" => {
+            "key0" => {
+              "element0" => "common"
+            },
+            "key1" => {
+              "element2" => "env"
+            },
+            "key2" => {
+              "element3" => {
+                "subelement3" => "env"
+              }
+            },
+            "key3" => "env"
+          },
+          "admins" => [
+            "joseph",
+            "gerald",
+            "craig",
+          ],
+          "jewels" => [
+            "ruby",
+            "opal",
+            "diamond",
+          ],
+          "cities" => {
+            "spain" => "madrid",
+            "argentina" => "buenos aires",
+            "france"=>"paris",
+            "uk"=>"london",
+          },
+          "databases" => {
+            "mdb" => {
+              "syncrepl" => {
+                "foo" => "bar",
+                "taz" => "tango"
+              }
+            },
+            "other_database" => {
+              "foo" => {
+                "bar" => nil
+              }
+            }
+          },
+          "boolfalse" => false,
+          "booltrue" => true,
+          "msgpack" => {
+            "values"=>{
+              1=>"Test 1",
+              "2"=>"Test 2"
+            }
+          },
+          "null_value" => nil,
+          "passwords" => {
+            "root"=>"vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+          },
+          "root_password" => "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA==",
+          "sub_value" => "Environment is %{env}",
+          "subhash" => {
+            "walk"=>{
+              "another"=>{
+                "deeper"=>"%{env}"
+              },
+              "replace"=>"%{env}"
+            }
+          },
+          "users" => [
+            "joshua",
+            "craig",
+            "karina",
+            "max"
+          ]
+        })
+      end
+    end
+
+    context 'cascade merge deep_hash result lookup' do
+      let(:request) do
+        Jerakia::Request.new(
+          policy: 'schema',
+          key: nil,
+          metadata: { env: 'dev' },
+          lookup_type: :cascade,
+          merge: :deep_hash,
+          namespace: ['test']
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should contain the string valid_string' do
+        expect(answer.payload).to eq({
+          "teststring" => "valid_string",
+          "accounts" => {
+            "admin" => {
+              "uid" => 99
+            },
+            "oracle" => {
+              "uid" => 500
+            }
+          },
+          "beers" => [
+            "cruzcampo",
+            "sanmiguel",
+          ],
+          "hash" => {
+            "key0" => {
+              "element0" => "common"
+            },
+            "key1" => {
+              "element1" => "common",
+              "element2" => "env"
+            },
+            "key2" => {
+              "element1" => "common",
+              "element2" => {
+                "subelement2" => "common"
+              },
+              "element3" => {
+                "subelement3" => "env"
+              }
+            },
+            "key3" => "env"
+          },
+          "admins" => [
+            "joseph",
+            "gerald",
+            "craig",
+          ],
+          "jewels" => [
+            "ruby",
+            "opal",
+            "diamond",
+            "quartz",
+            "topaz",
+          ],
+          "cities" => {
+            "spain" => "madrid",
+            "argentina" => "buenos aires",
+            "france"=>"paris",
+            "uk"=>"london",
+          },
+          "databases" => {
+            "mdb" => {
+              "boo" => {
+                "bear" => "baz"
+              },
+              "otherstuff" => {
+                "yea" => "man"
+              },
+              "syncrepl" => {
+                "foo" => "bar",
+                "taz" => "tango"
+              }
+            },
+            "other_database" => {
+              "foo" => {
+                "bar" => nil
+              }
+            }
+          },
+          "boolfalse" => false,
+          "booltrue" => true,
+          "msgpack" => {
+            "values"=>{
+              1=>"Test 1",
+              "2"=>"Test 2"
+            }
+          },
+          "null_value" => nil,
+          "passwords" => {
+            "root"=>"vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+          },
+          "root_password" => "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA==",
+          "sub_value" => "Environment is %{env}",
+          "subhash" => {
+            "walk"=>{
+              "another"=>{
+                "deeper"=>"%{env}"
+              },
+              "replace"=>"%{env}"
+            }
+          },
+          "users" => [
+            "joshua",
+            "craig",
+            "karina",
+            "max"
+          ]
+        })
+      
+      end
+    end
+
+    context 'cascade merge deep_all result lookup' do
+      let(:request) do
+        Jerakia::Request.new(
+          policy: 'schema',
+          key: nil,
+          metadata: { env: 'dev' },
+          lookup_type: :cascade,
+          merge: :deep_all,
+          namespace: ['test']
+        )
+      end
+
+      it 'should return a response' do
+        expect(answer).to be_a(Jerakia::Answer)
+      end
+
+      it 'should contain the string valid_string' do
+        expect(answer.payload).to eq({
+          "teststring" => "valid_string",
+          "accounts" => {
+            "admin" => {
+              "uid" => 99
+            },
+            "oracle" => {
+              "uid" => 500
+            }
+          },
+          "beers" => [
+            "cruzcampo",
+            "sanmiguel",
+            "estrella",
+            "victoria",
+            ],
+          "hash" => {
+            "key0" => {
+              "element0" => "common"
+            },
+            "key1" => {
+              "element1" => "common",
+              "element2" => "env"
+            },
+            "key2" => {
+              "element1" => "common",
+              "element2" => {
+                "subelement2" => "common"
+              },
+              "element3" => {
+                "subelement3" => "env"
+              }
+            },
+            "key3" => "env"
+          },
+          "admins" => [
+            "joseph",
+            "gerald",
+            "craig",
+            "bill",
+            "susan",
+            "fred",
+            "bob",
+          ],
+          "jewels" => [
+            "ruby",
+            "opal",
+            "diamond",
+            "quartz",
+            "topaz",
+          ],
+          "cities" => {
+            "spain" => "madrid",
+            "argentina" => "buenos aires",
+            "france"=>"paris",
+            "uk"=>"london",
+          },
+          "databases" => {
+          "mdb" => {
+              "boo" => {
+                "bear" => "baz"
+              },
+              "otherstuff" => {
+                "yea" => "man"
+              },
+                "syncrepl" => {
+                "foo" => "bar",
+                "taz" => "tango"
+              }
+            },
+            "other_database" => {
+              "foo" => {
+                "bar" => nil
+              }
+            }
+          },
+          "boolfalse" => false,
+          "booltrue" => true,
+          "msgpack" => {
+            "values"=>{
+              1=>"Test 1",
+              "2"=>"Test 2"
+            }
+          },
+          "null_value" => nil,
+          "passwords" => {
+            "root"=>"vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA=="
+          },
+          "root_password" => "vault:v1:HBlr4Ao2oUYBOqgzwbZOKrn63HyduS2y9QYZklXgBOuENA==",
+          "sub_value" => "Environment is %{env}",
+          "subhash" => {
+            "walk"=>{
+              "another"=>{
+                "deeper"=>"%{env}"
+              },
+              "replace"=>"%{env}"
+            }
+          },
+          "users" => [
+            "joshua",
+            "craig",
+            "karina",
+            "max"
+          ]
+        })
+      end
+    end
+
+  end
+end

--- a/spec/features/stop_spec.rb
+++ b/spec/features/stop_spec.rb
@@ -22,7 +22,7 @@ describe Jerakia do
       end
 
       it 'should return the answer' do
-        expect(answer.payload).to eq(['Success'])
+        expect(answer.payload).to eq('Success')
       end
 
     end


### PR DESCRIPTION
by using keyless lookups with cascade and merge set to array/hash/deep_hash, each found key will try to merge its values, resulting in type errors for strings, ints, etc...

This PR checks the type and adds a 'deep_all' option to be used for merge, which will deep_merge all hashes and arrays. Standard usage of the merge options should work as always. (Not sure about this as I'm really new to jerakia)
