### PR TITLE
Ensure Docker can target Jerakia directly to stop container

### DIFF
--- a/jerakia.docker
+++ b/jerakia.docker
@@ -5,5 +5,4 @@ if [ "${tokens}" != "" ]; then
   extra_args="${extra_args} -T ${tokens}"
 fi
 
-jerakia $* $extra_args
-
+exec jerakia $* $extra_args


### PR DESCRIPTION
When gracefully stopping a container, Docker will send the SIGTERM
signal to PID 1 inside container. Before this commit, this was bash
and not jerakia. bash doesn't do anything when receiving SIGTERM or
SIGINT. This made the container take a long time to stop correctly.